### PR TITLE
added canonical link

### DIFF
--- a/src/main/java/com/arcbees/seo/SeoElements.java
+++ b/src/main/java/com/arcbees/seo/SeoElements.java
@@ -29,6 +29,7 @@ public class SeoElements {
         private Image image;
         private TwitterCard twitterCard;
         private Map<String, String> customMetaTags;
+        private String canonical;
 
         public Builder() {
             customMetaTags = new LinkedHashMap<>();
@@ -74,6 +75,11 @@ public class SeoElements {
             return this;
         }
 
+        public Builder withCanonical(String canonical) {
+            this.canonical = canonical;
+            return this;
+        }
+
         public SeoElements build() {
             SeoElements seoElements = new SeoElements();
 
@@ -85,6 +91,7 @@ public class SeoElements {
             seoElements.setCustomMetaTags(customMetaTags);
             seoElements.setTwitterCard(twitterCard);
             seoElements.setImage(image);
+            seoElements.setCanonical(canonical);
 
             return seoElements;
         }
@@ -98,6 +105,7 @@ public class SeoElements {
     private OpenGraph openGraph;
     private TwitterCard twitterCard;
     private Map<String, String> customMetaTags;
+    private String canonical;
 
     public String getTitle() {
         return title;
@@ -163,6 +171,14 @@ public class SeoElements {
         this.customMetaTags = customMetaTags;
     }
 
+    public String getCanonical() {
+        return canonical;
+    }
+
+    public void setCanonical(String canonical) {
+        this.canonical = canonical;
+    }
+
     @Override
     public String toString() {
         return "SeoElements{" +
@@ -174,6 +190,7 @@ public class SeoElements {
                 ", openGraph=" + openGraph +
                 ", twitterCard=" + twitterCard +
                 ", customMetaTags=" + customMetaTags +
+                ", canonical=" + canonical +
                 '}';
     }
 }

--- a/src/main/java/com/arcbees/seo/TagsInjector.java
+++ b/src/main/java/com/arcbees/seo/TagsInjector.java
@@ -23,10 +23,12 @@ import com.arcbees.seo.widget.OgType;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.HeadElement;
+import com.google.gwt.dom.client.LinkElement;
 import com.google.gwt.dom.client.MetaElement;
 import com.google.gwt.dom.client.NodeList;
 
 public class TagsInjector {
+    private static final String REL_CANONICAL = "canonical";
     private final Document document;
 
     public TagsInjector() {
@@ -44,6 +46,7 @@ public class TagsInjector {
         }
 
         setMetaTags(seoElements);
+        setCanonical(seoElements.getCanonical());
     }
 
     public void setMetaTag(String property, String content) {
@@ -132,6 +135,30 @@ public class TagsInjector {
             name = metaElement.getAttribute("property");
         }
         return name;
+    }
+
+    public void setCanonical(String canonical) {
+        HeadElement head = document.getHead();
+        NodeList<Element> linkElements = head.getElementsByTagName("link");
+        LinkElement canonicalLink = null;
+        for (int i = 0; i < linkElements.getLength() && canonicalLink == null; i++) {
+            LinkElement linkElement = (LinkElement) linkElements.getItem(i);
+            if (REL_CANONICAL.equals(linkElement.getRel())) {
+                canonicalLink = linkElement;
+            }
+        }
+        if (isNullOrEmpty(canonical)) {
+            if (canonicalLink != null) {
+                head.removeChild(canonicalLink);
+            }
+        } else {
+            if (canonicalLink == null) {
+                canonicalLink = document.createLinkElement();
+                canonicalLink.setRel(REL_CANONICAL);
+                head.insertFirst(canonicalLink);
+            }
+            canonicalLink.setHref(canonical);
+        }
     }
 
     private static boolean isNullOrEmpty(String value) {

--- a/src/main/java/com/arcbees/seo/widget/CanonicalLink.java
+++ b/src/main/java/com/arcbees/seo/widget/CanonicalLink.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.arcbees.seo.widget;
+
+public class CanonicalLink extends TextNode {
+}

--- a/src/main/java/com/arcbees/seo/widget/SeoWidget.java
+++ b/src/main/java/com/arcbees/seo/widget/SeoWidget.java
@@ -95,6 +95,10 @@ public class SeoWidget extends ContainerNode implements AttachEvent.Handler {
         seoBuilder.withMetaTag(custom.getProperty(), custom.getText());
     }
 
+    public void add(CanonicalLink canonical) {
+        seoBuilder.withCanonical(canonical.getText());
+    }
+
     @Override
     public void onAttachOrDetach(AttachEvent event) {
         if (event.isAttached()) {


### PR DESCRIPTION
- SeoElements Builder can be used with method withCanonical(String)
- in Seo Widget the link can be included with <seo:CanonicalLink> tag

As requested in https://github.com/ArcBees/gwt-seo/pull/7 I've separated the canonical link stuff.
Let me know if you're interested in the meta tag fixes, I'll create a separate request for it.

PS: it's live in action on https://www.interlubes.de/